### PR TITLE
no organizer when confirming via the command

### DIFF
--- a/pretix_eth/management/commands/confirm_payments.py
+++ b/pretix_eth/management/commands/confirm_payments.py
@@ -109,7 +109,8 @@ class Command(BaseCommand):
 
                 if no_dry_run:
                     logger.info(f'  * Confirming order payment {full_id}')
-                    order_payment.confirm()
+                    with scope(organizer=None):
+                        order_payment.confirm()
                 else:
                     logger.info(f'  * DRY RUN: Would confirm order payment {full_id}')
             else:


### PR DESCRIPTION
### What was wrong?

When running the management command with `--no-dry-run` we've run into another `scope` issue.

### How was it fixed?

In the management command we have to use `scope(organizer=None)`.



#### Cute Animal Picture

![Cute animal picture]()
